### PR TITLE
Safe LoadLibrary usage

### DIFF
--- a/SHVistaPathMap.hpp
+++ b/SHVistaPathMap.hpp
@@ -45,7 +45,7 @@ public:
 
             ExpandEnvironmentStringsW(szMod, szExpanded, ARRAYSIZE(szExpanded));
 
-            if (HMODULE hMod = LoadLibraryW(szExpanded))
+            if (HMODULE hMod = LoadLibraryExW(szExpanded, NULL, LOAD_LIBRARY_AS_DATAFILE))
             {
                 if (LoadStringW(hMod, nResID, szLocalized, ARRAYSIZE(szLocalized)))
                 {


### PR DESCRIPTION
Use LoadLibrayEx with the LOAD_LIBRARY_AS_DATAFILE flag when reading resources from unknown locations.